### PR TITLE
Fix: changed Dockerfile to make the image 3 times lighter.

### DIFF
--- a/Docker/CMD.sh
+++ b/Docker/CMD.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-CMD="/lib/elastix-install/bin/elastix"
+CMD="elastix"
 
 if [ -f "/Data/Fixed_image.mha" ]; then
     FIXED="/Data/Fixed_image.mha"

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,45 +1,44 @@
-# syntax = docker/dockerfile:1.2
+FROM nvidia/cuda:12.9.0-cudnn-devel-ubuntu24.04 AS builder
 
-FROM nvidia/cuda:12.9.0-cudnn-devel-ubuntu24.04
-
-ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git wget unzip cmake ninja-build build-essential openmpi-bin libopenmpi-dev \
  && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /lib
+WORKDIR /build
 
-RUN git clone https://github.com/InsightSoftwareConsortium/ITK.git
-RUN mkdir /lib/ITK-build && mkdir /lib/ITK-install
-WORKDIR /lib/ITK-build
-RUN cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX=/lib/ITK-install /lib/ITK \
- && ninja -j"$(nproc)" install
+RUN git clone https://github.com/InsightSoftwareConsortium/ITK.git && \
+    mkdir ITK-build && cd ITK-build && \
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/install/ITK ../ITK && \
+    ninja install && \
+    rm -rf /build/ITK /build/ITK-build
 
-WORKDIR /lib
-RUN wget -O libtorch.zip https://download.pytorch.org/libtorch/cu129/libtorch-shared-with-deps-2.8.0%2Bcu129.zip
-RUN unzip libtorch.zip -d . && rm libtorch.zip
+RUN wget -O libtorch.zip https://download.pytorch.org/libtorch/cu129/libtorch-shared-with-deps-2.8.0%2Bcu129.zip && \
+    unzip libtorch.zip -d /install && rm libtorch.zip
 
-ENV PATH="/usr/local/cuda/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
+RUN git clone https://github.com/vboussot/ImpactElastix.git && \
+    mkdir elastix-build && cd elastix-build && \
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
+          -DTorch_DIR=/install/libtorch/share/cmake/Torch/ \
+          -DITK_DIR=/install/ITK/lib/cmake/ITK-6.0 \
+          -DUSE_ImpactMetric=ON \
+          -DCMAKE_INSTALL_PREFIX=/install/elastix \
+          ../ImpactElastix && \
+    ninja install && \
+    rm -rf /build/ImpactElastix /build/elastix-build
 
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+FROM nvidia/cuda:12.9.0-cudnn-runtime-ubuntu24.04
 
-RUN git clone https://github.com/vboussot/ImpactElastix.git
-RUN mkdir -p /lib/elastix-build /lib/elastix-install
-WORKDIR /lib/elastix-build
+ENV NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
-RUN cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
-    -DTorch_DIR=/lib/libtorch/share/cmake/Torch/ \
-    -DITK_DIR=/lib/ITK-install/lib/cmake/ITK-6.0 \
-    -DUSE_ImpactMetric=ON \
-    -DCMAKE_INSTALL_PREFIX=/lib/elastix-install \
-    /lib/ImpactElastix \
- && ninja -j"$(nproc)" install
+COPY --from=builder /install/ITK /usr/local/ITK
+COPY --from=builder /install/libtorch /usr/local/libtorch
+COPY --from=builder /install/elastix /usr/local/elastix
 
-WORKDIR /lib
-ENV LD_LIBRARY_PATH="/lib/libtorch/lib/:/lib/elastix-install/lib/:${LD_LIBRARY_PATH}"
-COPY CMD.sh /lib/CMD.sh
-RUN chmod +x /lib/CMD.sh
-CMD ["./CMD.sh"]
+ENV LD_LIBRARY_PATH="/usr/local/libtorch/lib:/usr/local/elastix/lib:${LD_LIBRARY_PATH}"
+ENV PATH="/usr/local/elastix/bin:$PATH"
+
+COPY CMD.sh /opt/CMD.sh
+RUN chmod +x /opt/CMD.sh
+
+CMD ["/opt/CMD.sh"]


### PR DESCRIPTION
I simply changed the CMD.sh and Dockerfile.
The Dockerfile kept all of the compilation junk, thus making the image weight ~ 63GB vs ~20GB now :

IMAGE                       ID             DISK USAGE   CONTENT SIZE   EXTRA
elastix_impact:my_version   1802bd022eb2       19.7GB         7.41GB

A simple multi-stage build fixed it.