### PR TITLE
Fix TorchScript export: fuser-safe shape checks + MIND conv padding

### DIFF
--- a/Data/Models/builds/Anatomix/Anatomix.py
+++ b/Data/Models/builds/Anatomix/Anatomix.py
@@ -8,7 +8,7 @@ class Normalize(torch.nn.Module):
         super().__init__()
         
     def forward(self, x: torch.Tensor, stats: torch.Tensor) -> torch.Tensor:
-        if stats.shape[0] == 4:
+        if stats.numel() == 4:
             return (x - stats[0]) / (stats[1] - stats[0] + 1e-6)
         else:
             vmin = x.min()

--- a/Data/Models/builds/Dino/Dinov2.py
+++ b/Data/Models/builds/Dino/Dinov2.py
@@ -8,7 +8,7 @@ class StandardizeImageNet(torch.nn.Module):
         self.register_buffer("std",  torch.tensor([0.229, 0.224, 0.225]).view(1, 3, 1, 1))
             
     def forward(self, x: torch.Tensor, stats: torch.Tensor) -> torch.Tensor:
-        if stats.shape[0] == 4:
+        if stats.numel() == 4:
             minv = stats[0]
             maxv = stats[1]
         else:

--- a/Data/Models/builds/Dino/convnext.py
+++ b/Data/Models/builds/Dino/convnext.py
@@ -24,7 +24,7 @@ class StandardizeImageNet(torch.nn.Module):
         self.register_buffer("std",  torch.tensor([0.229, 0.224, 0.225]).view(1, 3, 1, 1))
             
     def forward(self, x: torch.Tensor, stats: torch.Tensor) -> torch.Tensor:
-        if stats.shape[0] == 4:
+        if stats.numel() == 4:
             minv = stats[0]
             maxv = stats[1]
         else:

--- a/Data/Models/builds/MRSeg/MRSeg.py
+++ b/Data/Models/builds/MRSeg/MRSeg.py
@@ -43,7 +43,7 @@ class Standardize(torch.nn.Module):
         super().__init__()
     
     def forward(self, x: torch.Tensor, stats: torch.Tensor) -> torch.Tensor:
-        if stats.shape[0] == 4:
+        if stats.numel() == 4:
             return (x-stats[2])/stats[3]
         else:
             return (x-x.mean())/x.std()

--- a/Data/Models/builds/Mind/Mind.py
+++ b/Data/Models/builds/Mind/Mind.py
@@ -10,7 +10,7 @@ class Normalize(torch.nn.Module):
         super().__init__()
         
     def forward(self, x: torch.Tensor, stats: torch.Tensor) -> torch.Tensor:
-        if stats.shape[0] == 4:
+        if stats.numel() == 4:
             return (x - stats[0]) / (stats[1] - stats[0] + 1e-6)
         else:
             vmin = x.min()
@@ -47,8 +47,8 @@ class Mind3D(torch.nn.Module):
         mshift2 = torch.zeros(12, 1, 3, 3, 3)
         mshift2.view(-1)[torch.arange(12) * 27 + idx_shift2[:,0] * 9 + idx_shift2[:, 1] * 3 + idx_shift2[:, 2]] = 1
 
-        self.conv1 = nn.Conv3d(1, 12, kernel_size=3, stride=1, padding=1, bias=False, dilation=dilation, groups=1)
-        self.conv2 = nn.Conv3d(1, 12, kernel_size=3, stride=1, padding=1, bias=False, dilation=dilation, groups=1)
+        self.conv1 = nn.Conv3d(1, 12, kernel_size=3, stride=1, padding=0, bias=False, dilation=dilation, groups=1)
+        self.conv2 = nn.Conv3d(1, 12, kernel_size=3, stride=1, padding=0, bias=False, dilation=dilation, groups=1)
 
         self.conv1.weight = nn.Parameter(mshift1, requires_grad=False)
         self.conv2.weight = nn.Parameter(mshift2, requires_grad=False)
@@ -108,9 +108,9 @@ class Mind2D(nn.Module):
         mshift1.view(-1)[torch.arange(num_pairs) * 9 + idx_shift1[:, 0] * 3 + idx_shift1[:, 1]] = 1
         mshift2.view(-1)[torch.arange(num_pairs) * 9 + idx_shift2[:, 0] * 3 + idx_shift2[:, 1]] = 1
 
-        self.conv1 = nn.Conv2d(1, num_pairs, kernel_size=3, stride=1, padding=1,
+        self.conv1 = nn.Conv2d(1, num_pairs, kernel_size=3, stride=1, padding=0,
                                bias=False, dilation=dilation, groups=1)
-        self.conv2 = nn.Conv2d(1, num_pairs, kernel_size=3, stride=1, padding=1,
+        self.conv2 = nn.Conv2d(1, num_pairs, kernel_size=3, stride=1, padding=0,
                                bias=False, dilation=dilation, groups=1)
 
         self.conv1.weight = nn.Parameter(mshift1, requires_grad=False)

--- a/Data/Models/builds/SAM/SAM2.1.py
+++ b/Data/Models/builds/SAM/SAM2.1.py
@@ -12,7 +12,7 @@ class StandardizeImageNet(torch.nn.Module):
         self.register_buffer("std",  torch.tensor([0.229, 0.224, 0.225]).view(1, 3, 1, 1))
             
     def forward(self, x: torch.Tensor, stats: torch.Tensor) -> torch.Tensor:
-        if stats.shape[0] == 4:
+        if stats.numel() == 4:
             minv = stats[0]
             maxv = stats[1]
         else:

--- a/Data/Models/builds/TS/TS.py
+++ b/Data/Models/builds/TS/TS.py
@@ -63,7 +63,7 @@ class Standardize(torch.nn.Module):
         super().__init__()
     
     def forward(self, x: torch.Tensor, stats: torch.Tensor) -> torch.Tensor:
-        if stats.shape[0] == 4:
+        if stats.numel() == 4:
             return (x-stats[2])/stats[3]
         else:
             return (x-x.mean())/x.std()
@@ -80,7 +80,7 @@ class Canonical(torch.nn.Module):
         super().__init__()
 
     def get_permute_and_flip(self, direction: torch.Tensor) -> tuple[bool, bool, bool, int, int, int] | None:
-        if direction.dim() != 2 or direction.shape[0] != 3 or direction.shape[1] != 3: 
+        if direction.dim() != 2 or direction.size(0) != 3 or direction.size(1) != 3: 
             return None
         
         A = torch.diag(torch.tensor([-1., -1., 1.], dtype=torch.double)) @ direction.to(torch.double).T

--- a/Data/Models/builds/VGG/VGG.py
+++ b/Data/Models/builds/VGG/VGG.py
@@ -10,7 +10,7 @@ class StandardizeImageNet(torch.nn.Module):
         self.register_buffer("std",  torch.tensor([0.229, 0.224, 0.225]).view(1, 3, 1, 1))
             
     def forward(self, x: torch.Tensor, stats: torch.Tensor) -> torch.Tensor:
-        if stats.shape[0] == 4:
+        if stats.numel() == 4:
             minv = stats[0]
             maxv = stats[1]
         else:


### PR DESCRIPTION
Two issues surfaced when consuming these exported models from C++ (LibTorch) with the default JIT graph-executor optimization (fusion) enabled — validated end-to-end against the ITKIMPACT ConvexAdam pipeline.

### 1. All models — fuser-safe shape check
The shared `Normalize` uses `if stats.shape[0] == 4`, which scripts to the variadic `aten::size(Tensor) -> int[]`. On some LibTorch builds the profiling executor's TensorExpr fuser aborts on it (`INTERNAL ASSERT FAILED ... We don't have an op for aten::size but it isn't a special case`) when the model is run repeatedly. Switching to `stats.numel() == 4` (and `direction.size(0/1)` in TS) keeps identical semantics with no variadic size op, so the graph stays fuser-safe. Consumers can then keep JIT optimization **on**, which roughly halves feature-extraction time versus globally disabling it.

Applied to: Mind, SAM2.1, MRSeg, VGG, Dinov2, Anatomix, convnext, TS.

### 2. MIND — conv padding
`conv1`/`conv2` used `padding=1` while a `ReplicationPad3d(dilation)` already pads the input, so the output was inflated by +2 per axis and shifted relative to the reference MINDSSC. Setting `padding=0` (rely solely on the replication pad) makes the output size equal the input and match convexAdam's `MINDSSC` (channel sum-of-squares diff `< 6e-3`, i.e. registration-identical; the channel order differs but is SSD/L2-invariant).

